### PR TITLE
Fixed mod disabling in MP

### DIFF
--- a/Configs.cs
+++ b/Configs.cs
@@ -49,7 +49,7 @@ namespace tMusicPlayer
 		public bool ResettingPanels { get; set; }
 
 		public override void OnChanged() {
-			if (!Main.gameMenu) {
+			if (!Main.gameMenu && !Main.dedServ) {
 				MusicPlayerUI UI = MusicUISystem.MusicUI;
 				if (ResettingPanels) {
 					UI.MusicPlayerPanel.Left.Pixels = 1115f;

--- a/MusicPlayerPlayer.cs
+++ b/MusicPlayerPlayer.cs
@@ -53,7 +53,7 @@ namespace tMusicPlayer
 			// Terraria source code uses UpdateEquips and sets Main.musicBox2 to determine music.
 			// By updating Main.musicBox2 again in PostUpdateEquips, the music player effectively becomes top priority.
 			// MusicBox2 has its own special numbers, automatically detected within our MusicData entries
-			if (!Main.gameMenu && MusicUISystem.MusicUI != null && MusicUISystem.MusicUI.playingMusic > -1) {
+			if (!Main.gameMenu && !Main.dedServ && MusicUISystem.MusicUI != null && MusicUISystem.MusicUI.playingMusic > -1) {
 				int index = tMusicPlayer.AllMusic.FindIndex(x => x.music == MusicUISystem.MusicUI.playingMusic);
 				Main.musicBox2 = tMusicPlayer.AllMusic[index].mainMusicBox2;
 			}

--- a/MusicUISystem.cs
+++ b/MusicUISystem.cs
@@ -46,17 +46,17 @@ namespace tMusicPlayer
 				}
 			}
 
-			MusicPlayerUI UI = MusicUISystem.MusicUI;
-
-			if (UI.sortType == SortBy.ID) {
-				tMusicPlayer.AllMusic = tMusicPlayer.AllMusic.OrderBy(x => x.music).ToList();
-			}
-			if (UI.sortType == SortBy.Name) {
-				tMusicPlayer.AllMusic = tMusicPlayer.AllMusic.OrderBy(x => x.name).ToList();
-			}
-
 			// Setup UI's item slot count.
 			if (!Main.dedServ) {
+				MusicPlayerUI UI = MusicUISystem.MusicUI;
+
+				if (UI.sortType == SortBy.ID) {
+					tMusicPlayer.AllMusic = tMusicPlayer.AllMusic.OrderBy(x => x.music).ToList();
+				}
+				if (UI.sortType == SortBy.Name) {
+					tMusicPlayer.AllMusic = tMusicPlayer.AllMusic.OrderBy(x => x.name).ToList();
+				}
+				
 				UI.SelectionSlots = new MusicBoxSlot[tMusicPlayer.AllMusic.Count];
 				UI.musicData = new List<MusicData>(tMusicPlayer.AllMusic);
 				UI.OrganizeSelection(SortBy.ID, ProgressBy.None, "", true);


### PR DESCRIPTION
* Added some Main.dedServ checks to UI code.

The mod was auto-disabling in multiplayer because some code in MusicUISystem was trying to access the UI when it didn't exist. I didn't notice any bugs with the other code I changed, but I figured it wouldn't hurt to be safe.